### PR TITLE
migrate: replace springframework.lang annotations with JSpecify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>1.0.0</version>
+            </dependency>
 
             <dependency>
                 <groupId>io.github.asekka</groupId>

--- a/spring-agent-flow-checkpoint/pom.xml
+++ b/spring-agent-flow-checkpoint/pom.xml
@@ -26,6 +26,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-client-chat</artifactId>
         </dependency>

--- a/spring-agent-flow-checkpoint/src/main/java/io/github/asekka/springai/agents/checkpoint/RedisCheckpointStore.java
+++ b/spring-agent-flow-checkpoint/src/main/java/io/github/asekka/springai/agents/checkpoint/RedisCheckpointStore.java
@@ -8,7 +8,7 @@ import io.github.asekka.springai.agents.graph.Checkpoint;
 import io.github.asekka.springai.agents.graph.CheckpointStore;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Redis-backed {@link CheckpointStore}. Each run is stored under

--- a/spring-agent-flow-checkpoint/src/main/java/io/github/asekka/springai/agents/checkpoint/package-info.java
+++ b/spring-agent-flow-checkpoint/src/main/java/io/github/asekka/springai/agents/checkpoint/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+package io.github.asekka.springai.agents.checkpoint;
+
+import org.jspecify.annotations.NullMarked;
+
+

--- a/spring-agent-flow-cli-agents/pom.xml
+++ b/spring-agent-flow-cli-agents/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/spring-agent-flow-cli-agents/src/main/java/io/github/asekka/springai/agents/cliagents/CliAgentNode.java
+++ b/spring-agent-flow-cli-agents/src/main/java/io/github/asekka/springai/agents/cliagents/CliAgentNode.java
@@ -14,7 +14,7 @@ import org.springaicommunity.agents.model.AgentResponse;
 import org.springaicommunity.agents.model.AgentTaskRequest;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Adapts a {@code spring-ai-community} {@link AgentModel} (the SPI behind

--- a/spring-agent-flow-cli-agents/src/main/java/io/github/asekka/springai/agents/cliagents/package-info.java
+++ b/spring-agent-flow-cli-agents/src/main/java/io/github/asekka/springai/agents/cliagents/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.github.asekka.springai.agents.cliagents;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-agent-flow-core/pom.xml
+++ b/spring-agent-flow-core/pom.xml
@@ -30,6 +30,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/spring-agent-flow-core/src/main/java/io/github/asekka/springai/agents/core/AgentResult.java
+++ b/spring-agent-flow-core/src/main/java/io/github/asekka/springai/agents/core/AgentResult.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record AgentResult(
         @Nullable String text,

--- a/spring-agent-flow-core/src/main/java/io/github/asekka/springai/agents/core/InterruptRequest.java
+++ b/spring-agent-flow-core/src/main/java/io/github/asekka/springai/agents/core/InterruptRequest.java
@@ -2,7 +2,7 @@ package io.github.asekka.springai.agents.core;
 
 import java.util.Objects;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record InterruptRequest(String reason, @Nullable Object payload) {
 

--- a/spring-agent-flow-core/src/main/java/io/github/asekka/springai/agents/core/ToolCallRecord.java
+++ b/spring-agent-flow-core/src/main/java/io/github/asekka/springai/agents/core/ToolCallRecord.java
@@ -3,7 +3,7 @@ package io.github.asekka.springai.agents.core;
 import java.util.Map;
 import java.util.Objects;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record ToolCallRecord(
         int sequence,

--- a/spring-agent-flow-core/src/main/java/io/github/asekka/springai/agents/core/package-info.java
+++ b/spring-agent-flow-core/src/main/java/io/github/asekka/springai/agents/core/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.github.asekka.springai.agents.core;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-agent-flow-graph/pom.xml
+++ b/spring-agent-flow-graph/pom.xml
@@ -25,6 +25,12 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-observation</artifactId>

--- a/spring-agent-flow-graph/src/main/java/io/github/asekka/springai/agents/graph/AgentGraph.java
+++ b/spring-agent-flow-graph/src/main/java/io/github/asekka/springai/agents/graph/AgentGraph.java
@@ -16,7 +16,7 @@ import io.github.asekka.springai.agents.core.AgentResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.messages.Message;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 

--- a/spring-agent-flow-graph/src/main/java/io/github/asekka/springai/agents/graph/Checkpoint.java
+++ b/spring-agent-flow-graph/src/main/java/io/github/asekka/springai/agents/graph/Checkpoint.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 
 import io.github.asekka.springai.agents.core.AgentContext;
 import io.github.asekka.springai.agents.core.InterruptRequest;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public record Checkpoint(
         String runId,

--- a/spring-agent-flow-graph/src/main/java/io/github/asekka/springai/agents/graph/Node.java
+++ b/spring-agent-flow-graph/src/main/java/io/github/asekka/springai/agents/graph/Node.java
@@ -4,7 +4,7 @@ import io.github.asekka.springai.agents.core.Agent;
 import io.github.asekka.springai.agents.core.AgentContext;
 import io.github.asekka.springai.agents.core.AgentEvent;
 import io.github.asekka.springai.agents.core.AgentResult;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 
 public interface Node {

--- a/spring-agent-flow-graph/src/main/java/io/github/asekka/springai/agents/graph/package-info.java
+++ b/spring-agent-flow-graph/src/main/java/io/github/asekka/springai/agents/graph/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.github.asekka.springai.agents.graph;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-agent-flow-resilience4j/pom.xml
+++ b/spring-agent-flow-resilience4j/pom.xml
@@ -27,6 +27,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/spring-agent-flow-samples/pom.xml
+++ b/spring-agent-flow-samples/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>spring-agent-flow-squad</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
         <!-- Mistral AI for integration demo -->
         <dependency>
             <groupId>org.springframework.ai</groupId>

--- a/spring-agent-flow-squad/pom.xml
+++ b/spring-agent-flow-squad/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/spring-agent-flow-squad/src/main/java/io/github/asekka/springai/agents/squad/ExecutorAgent.java
+++ b/spring-agent-flow-squad/src/main/java/io/github/asekka/springai/agents/squad/ExecutorAgent.java
@@ -16,7 +16,7 @@ import org.springframework.ai.chat.client.ResponseEntity;
 import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.tool.ToolCallback;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;

--- a/spring-agent-flow-squad/src/main/java/io/github/asekka/springai/agents/squad/RecordingToolCallback.java
+++ b/spring-agent-flow-squad/src/main/java/io/github/asekka/springai/agents/squad/RecordingToolCallback.java
@@ -10,7 +10,7 @@ import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
 import org.springframework.ai.tool.metadata.ToolMetadata;
 import org.springframework.ai.util.json.JsonParser;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class RecordingToolCallback implements ToolCallback {
 

--- a/spring-agent-flow-squad/src/main/java/io/github/asekka/springai/agents/squad/ToolCallCollector.java
+++ b/spring-agent-flow-squad/src/main/java/io/github/asekka/springai/agents/squad/ToolCallCollector.java
@@ -8,7 +8,7 @@ import java.util.function.Consumer;
 
 import io.github.asekka.springai.agents.core.AgentEvent;
 import io.github.asekka.springai.agents.core.ToolCallRecord;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 final class ToolCallCollector {
 

--- a/spring-agent-flow-squad/src/main/java/io/github/asekka/springai/agents/squad/package-info.java
+++ b/spring-agent-flow-squad/src/main/java/io/github/asekka/springai/agents/squad/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.github.asekka.springai.agents.squad;
+
+import org.jspecify.annotations.NullMarked;

--- a/spring-agent-flow-starter/pom.xml
+++ b/spring-agent-flow-starter/pom.xml
@@ -24,6 +24,12 @@
             <groupId>io.github.asekka</groupId>
             <artifactId>spring-agent-flow-graph</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.github.asekka</groupId>
             <artifactId>spring-agent-flow-squad</artifactId>

--- a/spring-agent-flow-test/pom.xml
+++ b/spring-agent-flow-test/pom.xml
@@ -26,6 +26,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>


### PR DESCRIPTION
Closes #4 

- Added org.jspecify:jspecify to dependencyManagement
- Replaced all NonNull/Nullable imports across modules
- Added @NullMarked to package-info.java per package
- Build passing