### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Report a reproducible bug in Spring Agent Flow
+title: "[Bug]: "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+Describe the bug clearly and concisely.
+
+## Version
+
+- Spring Agent Flow version: <!-- e.g. v0.5.0 -->
+- Java version: <!-- Java 17+ -->
+- Maven version:
+- Spring Boot version: <!-- Spring Boot 3.x -->
+- Spring AI version: <!-- Spring AI 1.0+ -->
+- Module affected: <!-- core / graph / squad / checkpoint / resilience4j / starter / samples / cli-agents / test -->
+
+## Minimal reproducer
+
+Please provide a minimal example that reproduces the issue.
+
+```java
+// A short main() or test case is ideal.
+```
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What did you expect to happen?
+
+## Actual behavior
+
+What actually happened?
+
+## Environment
+
+- OS:
+- Runtime:
+- Database/checkpoint backend, if relevant: <!-- H2 / PostgreSQL / Redis / none -->
+- Docker used: <!-- yes / no -->
+
+## Logs or screenshots
+
+Paste logs, stack traces, screenshots, or error output here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,58 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+title: "[Feature]: "
+labels: enhancement
+assignees: ""
+---
+
+## Motivation
+
+Why is this feature needed?
+
+What problem does it solve for users of Spring Agent Flow?
+
+## Proposal
+
+Describe the proposed solution.
+
+## Affected area
+
+Which area would this change affect?
+
+- [ ] core
+- [ ] graph
+- [ ] squad
+- [ ] checkpoint
+- [ ] resilience4j
+- [ ] starter
+- [ ] samples
+- [ ] cli-agents
+- [ ] docs/recipes
+- [ ] other:
+
+## API or behavior impact
+
+Does this change affect the public API or default behavior?
+
+- [ ] No
+- [ ] Yes
+
+If yes, describe the impact:
+
+## Alternatives considered
+
+Describe any alternatives or workarounds you considered.
+
+## Tests and documentation
+
+Would this require tests or documentation updates?
+
+- [ ] Tests
+- [ ] Recipe under `docs/recipes/`
+- [ ] README update
+- [ ] Not sure
+
+## Additional context
+
+Add examples, links, screenshots, or related issues here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,41 @@
+---
+name: Question
+about: Ask a question about usage, configuration, or design
+title: "[Question]: "
+labels: question
+assignees: ""
+---
+
+## Question
+
+What would you like to know?
+
+## Context
+
+Describe what you are trying to build or understand.
+
+## What have you tried?
+
+List the documentation, recipes, examples, or code paths you already checked.
+
+## Relevant area
+
+- [ ] AgentGraph
+- [ ] CoordinatorAgent / ExecutorAgent / squad API
+- [ ] Checkpointing
+- [ ] Resilience / retry / circuit breaker
+- [ ] Spring Boot starter
+- [ ] CLI agents
+- [ ] Samples
+- [ ] Documentation
+- [ ] Other:
+
+## Code sample
+
+```java
+// Add a small example if helpful.
+```
+
+## Additional information
+
+Add links, logs, screenshots, or other details here.


### PR DESCRIPTION
## Summary

Add issue templates for bug reports, feature requests, and questions.

## Motivation

The repository currently does not guide contributors when opening new issues. These templates help collect the minimum information needed to make reports, proposals, and questions easier to triage.

## Changes

- Add a bug report template with reproduction steps, expected vs actual behavior, environment, and logs
- Add a feature request template with motivation, proposal, alternatives, and impact
- Add a question template for usage, configuration, and design questions
- Disable blank issues through `config.yml`

## API / behavior impact

No API or runtime behavior changes. This only affects the GitHub issue creation flow.

## Tests

Not applicable. The change only adds GitHub issue templates.

## Checklist

- [x] `bug_report.md` includes reproduction steps, expected vs actual behavior, and environment
- [x] `feature_request.md` includes motivation, proposal, and alternatives
- [x] `question.md` is available for questions
- [x] Templates are placed under `.github/ISSUE_TEMPLATE/` and should render when opening a new issue

Closes #1