### PR TITLE
Reason-aware RetryPolicy: TRANSIENT / PERMANENT / OVER_BUDGET (#14)

### DIFF
--- a/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/AgentGraph.java
+++ b/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/AgentGraph.java
@@ -386,14 +386,36 @@ public final class AgentGraph implements Agent {
                 break;
             }
             AgentError err = result.error();
-            boolean canRetry = i < attempts - 1
-                    && err != null && err.cause() != null
-                    && policy.retryOn().test(err.cause());
-            if (!canRetry) {
+            if (err == null || err.cause() == null) {
                 break;
             }
-            long delay = policy.computeDelayMs(i + 1);
-            log.warn("Node '{}' failed during stream, retrying ({}/{}) after {}ms",
+            FailureClassification classification = policy.classify(err.cause());
+            if (classification.category() == FailureCategory.OVER_BUDGET) {
+                String reason = classification.reason() != null
+                        ? classification.reason()
+                        : "node '" + node.name() + "' signaled budget exhaustion";
+                log.warn("Node '{}' over-budget during stream, interrupting: {}",
+                        node.name(), reason);
+                result = AgentResult.interrupted(
+                        new InterruptRequest("budget.exceeded:" + node.name(), reason));
+                break;
+            }
+            boolean canRetry = i < attempts - 1
+                    && classification.category() == FailureCategory.TRANSIENT;
+            if (!canRetry) {
+                if (classification.category() == FailureCategory.PERMANENT) {
+                    log.warn("Node '{}' failed (PERMANENT), no retry: {}",
+                            node.name(),
+                            classification.reason() != null
+                                    ? classification.reason()
+                                    : err.cause().getClass().getSimpleName());
+                }
+                break;
+            }
+            long delay = classification.retryAfter() != null
+                    ? classification.retryAfter().toMillis()
+                    : policy.computeDelayMs(i + 1);
+            log.warn("Node '{}' failed during stream (TRANSIENT), retrying ({}/{}) after {}ms",
                     node.name(), i + 1, attempts - 1, delay);
             sleep(delay);
         }
@@ -453,14 +475,35 @@ public final class AgentGraph implements Agent {
                 break;
             }
             AgentError err = result.error();
-            boolean canRetry = i < attempts - 1
-                    && err != null && err.cause() != null
-                    && policy.retryOn().test(err.cause());
-            if (!canRetry) {
+            if (err == null || err.cause() == null) {
                 break;
             }
-            long delay = policy.computeDelayMs(i + 1);
-            log.warn("Node '{}' failed, retrying ({}/{}) after {}ms",
+            FailureClassification classification = policy.classify(err.cause());
+            if (classification.category() == FailureCategory.OVER_BUDGET) {
+                String reason = classification.reason() != null
+                        ? classification.reason()
+                        : "node '" + node.name() + "' signaled budget exhaustion";
+                log.warn("Node '{}' over-budget, interrupting: {}", node.name(), reason);
+                result = AgentResult.interrupted(
+                        new InterruptRequest("budget.exceeded:" + node.name(), reason));
+                break;
+            }
+            boolean canRetry = i < attempts - 1
+                    && classification.category() == FailureCategory.TRANSIENT;
+            if (!canRetry) {
+                if (classification.category() == FailureCategory.PERMANENT) {
+                    log.warn("Node '{}' failed (PERMANENT), no retry: {}",
+                            node.name(),
+                            classification.reason() != null
+                                    ? classification.reason()
+                                    : err.cause().getClass().getSimpleName());
+                }
+                break;
+            }
+            long delay = classification.retryAfter() != null
+                    ? classification.retryAfter().toMillis()
+                    : policy.computeDelayMs(i + 1);
+            log.warn("Node '{}' failed (TRANSIENT), retrying ({}/{}) after {}ms",
                     node.name(), i + 1, attempts - 1, delay);
             sleep(delay);
         }

--- a/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/BudgetExceededException.java
+++ b/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/BudgetExceededException.java
@@ -1,0 +1,30 @@
+package io.github.datallmhub.agentflow4j.graph;
+
+/**
+ * Thrown from inside a node when it detects a budget exhaustion that the
+ * framework's {@link BudgetPolicy} could not gate beforehand — e.g. an LLM
+ * provider returned an HTTP 402 / "insufficient quota" payload, or the node's
+ * own bookkeeping says it would exceed a per-node ceiling.
+ *
+ * <p>The {@link FailureClassifier#defaults() default classifier} maps this
+ * exception to {@link FailureCategory#OVER_BUDGET}, which causes the graph
+ * to emit an {@link InterruptRequest} (reason {@code budget.exceeded:<node>})
+ * rather than retrying — retrying a budget condition just burns more money.
+ *
+ * <p>Use it for failures detected <em>during</em> execution. Failures detected
+ * <em>before</em> execution are handled by {@link BudgetPolicy#check} via the
+ * existing gate path; this exception is the runtime counterpart for cases the
+ * gate could not anticipate.
+ */
+public class BudgetExceededException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public BudgetExceededException(String message) {
+        super(message);
+    }
+
+    public BudgetExceededException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/DefaultFailureClassifier.java
+++ b/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/DefaultFailureClassifier.java
@@ -1,0 +1,157 @@
+package io.github.datallmhub.agentflow4j.graph;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Default {@link FailureClassifier} — knows about common JDK transient
+ * exceptions, Spring AI / Spring Web HTTP exceptions, and the framework's
+ * own {@link BudgetExceededException}.
+ *
+ * <p>Spring exceptions are detected by class name so this module stays free
+ * of any Spring dependency at compile time. The {@code Retry-After} header is
+ * extracted from {@code HttpClientErrorException.TooManyRequests} via
+ * reflection — best-effort, never throws.
+ *
+ * <p>Walks the cause chain so that wrapped exceptions (e.g.
+ * {@code CompletionException → IOException}) are classified by their root
+ * cause rather than the wrapper.
+ */
+final class DefaultFailureClassifier implements FailureClassifier {
+
+    static final DefaultFailureClassifier INSTANCE = new DefaultFailureClassifier();
+
+    private static final int MAX_CAUSE_CHAIN_DEPTH = 10;
+
+    private DefaultFailureClassifier() {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Returns {@code null} (declines) for exceptions the classifier does
+     * not specifically recognise — this lets the policy's legacy
+     * {@link RetryPolicy#retryOn()} predicate decide for unknown types, and
+     * keeps callers that only set {@code retryOn} working unchanged.
+     */
+    @Override
+    @Nullable
+    public FailureClassification classify(Throwable cause) {
+        if (cause == null) {
+            return FailureClassification.permanent("no cause");
+        }
+
+        for (Throwable t = cause; t != null; t = nextCause(t)) {
+            // 1. Explicit framework signal — wins everything.
+            if (t instanceof BudgetExceededException) {
+                String reason = t.getMessage() != null ? t.getMessage() : "budget exceeded";
+                return FailureClassification.overBudget(reason);
+            }
+
+            // 2. Spring AI / Spring Web HTTP, by class name (no compile-time dep).
+            String name = t.getClass().getName();
+            if (isTooManyRequests(name)) {
+                Duration retryAfter = readRetryAfter(t);
+                return retryAfter != null
+                        ? FailureClassification.transientFailure(retryAfter)
+                        : FailureClassification.transientFailure();
+            }
+            if (isHttpServerError(name)) {
+                return FailureClassification.transientFailure();
+            }
+            if (isHttpClientError(name)) {
+                return FailureClassification.permanent("HTTP 4xx (non-retryable)");
+            }
+            if (isResourceAccessError(name)) {
+                // Spring wraps low-level I/O failures here — treat as transient.
+                return FailureClassification.transientFailure();
+            }
+
+            // 3. Plain JDK transient I/O.
+            if (t instanceof IOException || t instanceof TimeoutException) {
+                return FailureClassification.transientFailure();
+            }
+        }
+
+        // Unknown — decline so the policy's retryOn predicate decides.
+        return null;
+    }
+
+    private static boolean isTooManyRequests(String className) {
+        return "org.springframework.web.client.HttpClientErrorException$TooManyRequests".equals(className);
+    }
+
+    private static boolean isHttpServerError(String className) {
+        return className.startsWith("org.springframework.web.client.HttpServerErrorException");
+    }
+
+    private static boolean isHttpClientError(String className) {
+        // Plain HttpClientErrorException or any of its concrete 4xx subclasses
+        // (BadRequest, Unauthorized, Forbidden, NotFound, MethodNotAllowed, …)
+        // EXCEPT TooManyRequests, which we already short-circuited above.
+        return className.startsWith("org.springframework.web.client.HttpClientErrorException");
+    }
+
+    private static boolean isResourceAccessError(String className) {
+        return "org.springframework.web.client.ResourceAccessException".equals(className);
+    }
+
+    /**
+     * Reads {@code Retry-After} from a Spring HTTP exception via reflection.
+     * Honours the integer-seconds form; HTTP-date form is not parsed in the
+     * MVP — falling back to {@code null} means the policy's normal backoff
+     * kicks in, which is a safe default.
+     */
+    @Nullable
+    private static Duration readRetryAfter(Throwable t) {
+        try {
+            Method getHeaders = t.getClass().getMethod("getResponseHeaders");
+            Object headers = getHeaders.invoke(t);
+            if (headers == null) {
+                return null;
+            }
+            Method get = headers.getClass().getMethod("get", Object.class);
+            Object value = get.invoke(headers, "Retry-After");
+            if (value instanceof List<?> list && !list.isEmpty()) {
+                String first = String.valueOf(list.get(0));
+                try {
+                    long seconds = Long.parseLong(first.trim());
+                    if (seconds < 0) {
+                        return null;
+                    }
+                    return Duration.ofSeconds(seconds);
+                }
+                catch (NumberFormatException ignored) {
+                    // HTTP-date form — not parsed in MVP, caller falls back to policy backoff.
+                    return null;
+                }
+            }
+        }
+        catch (Throwable ignored) {
+            // Reflection failure — the exception class doesn't expose headers
+            // (or has a different shape). Best-effort: no retry-after hint.
+        }
+        return null;
+    }
+
+    /** Returns the next cause, guarding against self-referential chains. */
+    @Nullable
+    private static Throwable nextCause(Throwable t) {
+        Throwable next = t.getCause();
+        if (next == null || next == t) {
+            return null;
+        }
+        // Bound the walk so a pathological chain can't loop forever.
+        int depth = 0;
+        for (Throwable c = t; c != null && depth < MAX_CAUSE_CHAIN_DEPTH; c = c.getCause(), depth++) {
+            if (c == next) {
+                return depth + 1 < MAX_CAUSE_CHAIN_DEPTH ? next : null;
+            }
+        }
+        return next;
+    }
+}

--- a/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/FailureCategory.java
+++ b/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/FailureCategory.java
@@ -1,0 +1,26 @@
+package io.github.datallmhub.agentflow4j.graph;
+
+/**
+ * Why a node attempt failed, from the retry layer's point of view.
+ *
+ * <p>The categories are deliberately minimal — three cover ~95% of real cases
+ * and keep the retry decision tree readable:
+ *
+ * <ul>
+ *   <li>{@link #TRANSIENT} — retry with backoff (or with the delay provided
+ *       by the failure itself, e.g. a {@code Retry-After} header).</li>
+ *   <li>{@link #PERMANENT} — do not retry; the next attempt would fail the
+ *       same way and just burn tokens.</li>
+ *   <li>{@link #OVER_BUDGET} — the failure indicates a budget exhaustion;
+ *       the graph emits an {@link InterruptRequest} so the caller can pause,
+ *       alert, raise the limit, and resume rather than crashing.</li>
+ * </ul>
+ *
+ * @see FailureClassifier
+ * @see FailureClassification
+ */
+public enum FailureCategory {
+    TRANSIENT,
+    PERMANENT,
+    OVER_BUDGET
+}

--- a/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/FailureClassification.java
+++ b/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/FailureClassification.java
@@ -1,0 +1,52 @@
+package io.github.datallmhub.agentflow4j.graph;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Outcome of classifying a node failure: its {@link FailureCategory}, an
+ * optional retry hint provided by the failure itself (e.g. a {@code Retry-After}
+ * header on an HTTP 429 response), and an optional human-readable reason.
+ *
+ * <p>Instances are produced by a {@link FailureClassifier} and consumed by
+ * the graph's retry layer. Use the static factories for the common cases.
+ */
+public record FailureClassification(
+        FailureCategory category,
+        @Nullable Duration retryAfter,
+        @Nullable String reason) {
+
+    public FailureClassification {
+        Objects.requireNonNull(category, "category");
+        if (retryAfter != null && retryAfter.isNegative()) {
+            throw new IllegalArgumentException("retryAfter must be non-negative");
+        }
+    }
+
+    /** Transient failure, retry with the policy's computed backoff. */
+    public static FailureClassification transientFailure() {
+        return new FailureClassification(FailureCategory.TRANSIENT, null, null);
+    }
+
+    /** Transient failure with an explicit retry delay (e.g. {@code Retry-After}). */
+    public static FailureClassification transientFailure(Duration retryAfter) {
+        return new FailureClassification(FailureCategory.TRANSIENT, retryAfter, null);
+    }
+
+    /** Permanent failure — the same call would fail the same way. */
+    public static FailureClassification permanent() {
+        return new FailureClassification(FailureCategory.PERMANENT, null, null);
+    }
+
+    /** Permanent failure with a reason recorded in logs and the audit trail. */
+    public static FailureClassification permanent(String reason) {
+        return new FailureClassification(FailureCategory.PERMANENT, null, reason);
+    }
+
+    /** Budget exhaustion — the graph emits an {@link InterruptRequest} for this. */
+    public static FailureClassification overBudget(String reason) {
+        return new FailureClassification(FailureCategory.OVER_BUDGET, null, reason);
+    }
+}

--- a/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/FailureClassifier.java
+++ b/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/FailureClassifier.java
@@ -1,0 +1,63 @@
+package io.github.datallmhub.agentflow4j.graph;
+
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Decides how a node failure should be handled: retried, given up on, or
+ * surfaced to the caller as an interrupt.
+ *
+ * <p>Classifiers compose with {@link #orElse(FailureClassifier)} — a custom
+ * classifier delegates the cases it does not know about to the default:
+ *
+ * <pre>{@code
+ * FailureClassifier customer = cause -> {
+ *     if (cause instanceof MyDomainException) return FailureClassification.permanent("domain rule");
+ *     return null; // unknown — let the next classifier decide
+ * };
+ * RetryPolicy policy = RetryPolicy.exponential(3, Duration.ofSeconds(1))
+ *         .withClassifier(customer.orElse(FailureClassifier.defaults()));
+ * }</pre>
+ *
+ * <p>Returning {@code null} from {@link #classify(Throwable)} means "I don't
+ * know" and lets {@link #orElse(FailureClassifier)} — or the policy's legacy
+ * {@code retryOn} predicate — decide instead.
+ */
+@FunctionalInterface
+public interface FailureClassifier {
+
+    /**
+     * Classify the failure. Returning {@code null} means the classifier
+     * declines to decide; useful when composing via {@link #orElse}.
+     */
+    @Nullable
+    FailureClassification classify(Throwable cause);
+
+    /**
+     * Compose with a fallback classifier. The fallback is consulted whenever
+     * this classifier returns {@code null}.
+     */
+    default FailureClassifier orElse(FailureClassifier fallback) {
+        Objects.requireNonNull(fallback, "fallback");
+        return cause -> {
+            FailureClassification self = classify(cause);
+            return self != null ? self : fallback.classify(cause);
+        };
+    }
+
+    /**
+     * Default classifier: recognises common JDK transient I/O exceptions
+     * ({@link java.io.IOException}, {@link java.util.concurrent.TimeoutException}),
+     * Spring AI / Spring Web HTTP exceptions (5xx + {@code 429} as TRANSIENT —
+     * honouring {@code Retry-After}; other 4xx as PERMANENT), and
+     * {@link BudgetExceededException} as {@link FailureCategory#OVER_BUDGET}.
+     * Everything else is {@link FailureCategory#PERMANENT}.
+     *
+     * <p>Detection of Spring exceptions is by class name to keep this module
+     * free of any Spring dependency at compile time.
+     */
+    static FailureClassifier defaults() {
+        return DefaultFailureClassifier.INSTANCE;
+    }
+}

--- a/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/RetryPolicy.java
+++ b/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/RetryPolicy.java
@@ -11,7 +11,8 @@ public record RetryPolicy(
         Duration maxDelay,
         double backoffMultiplier,
         double jitterFactor,
-        Predicate<Throwable> retryOn) {
+        Predicate<Throwable> retryOn,
+        FailureClassifier classifier) {
 
     public RetryPolicy {
         if (maxAttempts < 1) {
@@ -20,6 +21,7 @@ public record RetryPolicy(
         Objects.requireNonNull(baseDelay, "baseDelay");
         Objects.requireNonNull(maxDelay, "maxDelay");
         Objects.requireNonNull(retryOn, "retryOn");
+        Objects.requireNonNull(classifier, "classifier");
         if (baseDelay.isNegative() || maxDelay.isNegative()) {
             throw new IllegalArgumentException("delays must be non-negative");
         }
@@ -34,19 +36,58 @@ public record RetryPolicy(
         }
     }
 
+    /**
+     * Backward-compatible six-argument constructor — delegates with
+     * {@link FailureClassifier#defaults()}.
+     */
+    public RetryPolicy(int maxAttempts, Duration baseDelay, Duration maxDelay,
+                       double backoffMultiplier, double jitterFactor,
+                       Predicate<Throwable> retryOn) {
+        this(maxAttempts, baseDelay, maxDelay, backoffMultiplier, jitterFactor, retryOn,
+                FailureClassifier.defaults());
+    }
+
     public static RetryPolicy none() {
         return new RetryPolicy(1, Duration.ZERO, Duration.ZERO, 1.0, 0.0,
-                RetryPredicates.never());
+                RetryPredicates.never(), FailureClassifier.defaults());
     }
 
     public static RetryPolicy once() {
         return new RetryPolicy(2, Duration.ZERO, Duration.ZERO, 1.0, 0.0,
-                RetryPredicates.always());
+                RetryPredicates.always(), FailureClassifier.defaults());
     }
 
     public static RetryPolicy exponential(int maxAttempts, Duration baseDelay) {
         return new RetryPolicy(maxAttempts, baseDelay, baseDelay.multipliedBy(32),
-                2.0, 0.2, RetryPredicates.transientIo());
+                2.0, 0.2, RetryPredicates.transientIo(), FailureClassifier.defaults());
+    }
+
+    /**
+     * Classify a failure using this policy's {@link FailureClassifier},
+     * combined with the legacy {@link #retryOn() retryOn} predicate.
+     *
+     * <p>The classifier is consulted first. If it returns {@code null}
+     * (declines to decide), the {@code retryOn} predicate is used as a
+     * fallback: {@code true} → {@link FailureCategory#TRANSIENT},
+     * {@code false} → {@link FailureCategory#PERMANENT}. This keeps callers
+     * that only set {@code retryOn} working unchanged while letting new
+     * callers use the richer classifier API.
+     */
+    public FailureClassification classify(Throwable cause) {
+        FailureClassification c = classifier.classify(cause);
+        if (c != null) {
+            return c;
+        }
+        return retryOn.test(cause)
+                ? FailureClassification.transientFailure()
+                : FailureClassification.permanent();
+    }
+
+    /** Returns a copy of this policy with the given classifier installed. */
+    public RetryPolicy withClassifier(FailureClassifier other) {
+        Objects.requireNonNull(other, "classifier");
+        return new RetryPolicy(maxAttempts, baseDelay, maxDelay,
+                backoffMultiplier, jitterFactor, retryOn, other);
     }
 
     public long computeDelayMs(int attemptNumber) {

--- a/agentflow4j-graph/src/test/java/io/github/datallmhub/agentflow4j/graph/AgentGraphReasonAwareRetryTests.java
+++ b/agentflow4j-graph/src/test/java/io/github/datallmhub/agentflow4j/graph/AgentGraphReasonAwareRetryTests.java
@@ -1,0 +1,211 @@
+package io.github.datallmhub.agentflow4j.graph;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.github.datallmhub.agentflow4j.core.Agent;
+import io.github.datallmhub.agentflow4j.core.AgentContext;
+import io.github.datallmhub.agentflow4j.core.AgentResult;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the reason-aware retry layer at the graph level:
+ * OVER_BUDGET produces an {@link io.github.datallmhub.agentflow4j.core.InterruptRequest}
+ * rather than retrying; PERMANENT short-circuits the retry loop; TRANSIENT
+ * retries up to {@code maxAttempts}; the {@code Retry-After} hint takes
+ * precedence over the policy's computed backoff.
+ */
+class AgentGraphReasonAwareRetryTests {
+
+    @Test
+    void budgetExceededExceptionInterruptsRunInsteadOfRetrying() {
+        AtomicInteger calls = new AtomicInteger();
+        Agent overBudget = ctx -> {
+            calls.incrementAndGet();
+            throw new BudgetExceededException("monthly cap reached");
+        };
+
+        AgentGraph graph = AgentGraph.builder()
+                .addNode("billed", overBudget)
+                .retryPolicy(RetryPolicy.exponential(5, Duration.ZERO))
+                .build();
+
+        AgentResult result = graph.invoke(AgentContext.of("go"));
+
+        assertThat(result.isInterrupted()).isTrue();
+        assertThat(result.interrupt()).isNotNull();
+        assertThat(result.interrupt().reason()).isEqualTo("budget.exceeded:billed");
+        assertThat(calls.get()).isEqualTo(1); // no retry on budget exhaustion
+    }
+
+    @Test
+    void permanentFailureIsNotRetriedUnderDefaultClassifier() {
+        AtomicInteger calls = new AtomicInteger();
+        Agent broken = ctx -> {
+            calls.incrementAndGet();
+            throw new IllegalArgumentException("permanent");
+        };
+
+        AgentGraph graph = AgentGraph.builder()
+                .addNode("broken", broken)
+                .retryPolicy(RetryPolicy.exponential(5, Duration.ZERO))
+                .build();
+
+        AgentResult result = graph.invoke(AgentContext.of("go"));
+
+        assertThat(result.hasError()).isTrue();
+        assertThat(calls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void transientIoFailureIsRetriedUnderDefaultClassifier() {
+        AtomicInteger calls = new AtomicInteger();
+        Agent flaky = ctx -> {
+            int n = calls.incrementAndGet();
+            if (n < 3) {
+                throw new java.io.UncheckedIOException(new IOException("transient " + n));
+            }
+            return AgentResult.ofText("ok");
+        };
+
+        AgentGraph graph = AgentGraph.builder()
+                .addNode("flaky", flaky)
+                .retryPolicy(RetryPolicy.exponential(3, Duration.ZERO))
+                .build();
+
+        AgentResult result = graph.invoke(AgentContext.of("go"));
+
+        assertThat(result.completed()).isTrue();
+        assertThat(result.text()).isEqualTo("ok");
+        assertThat(calls.get()).isEqualTo(3);
+    }
+
+    @Test
+    void springClientErrorOtherThan429IsTreatedAsPermanent() {
+        AtomicInteger calls = new AtomicInteger();
+        Agent broken = ctx -> {
+            calls.incrementAndGet();
+            throw new org.springframework.web.client.HttpClientErrorException.BadRequest("400");
+        };
+
+        AgentGraph graph = AgentGraph.builder()
+                .addNode("broken", broken)
+                .retryPolicy(RetryPolicy.exponential(5, Duration.ZERO))
+                .build();
+
+        AgentResult result = graph.invoke(AgentContext.of("go"));
+
+        assertThat(result.hasError()).isTrue();
+        assertThat(calls.get()).isEqualTo(1); // 4xx → no retry
+    }
+
+    @Test
+    void springTooManyRequestsIsRetried() {
+        AtomicInteger calls = new AtomicInteger();
+        Agent flaky = ctx -> {
+            int n = calls.incrementAndGet();
+            if (n < 2) {
+                throw new org.springframework.web.client.HttpClientErrorException.TooManyRequests("429");
+            }
+            return AgentResult.ofText("ok");
+        };
+
+        AgentGraph graph = AgentGraph.builder()
+                .addNode("ratelimited", flaky)
+                .retryPolicy(RetryPolicy.exponential(3, Duration.ZERO))
+                .build();
+
+        AgentResult result = graph.invoke(AgentContext.of("go"));
+
+        assertThat(result.completed()).isTrue();
+        assertThat(calls.get()).isEqualTo(2);
+    }
+
+    @Test
+    void retryAfterHeaderTakesPrecedenceOverPolicyBackoff() {
+        // Policy would compute a 10-second backoff; Retry-After: 0 must win and
+        // make the retry essentially immediate. We assert via wall-clock that
+        // the call completed in well under the policy backoff.
+        AtomicInteger calls = new AtomicInteger();
+        Agent flaky = ctx -> {
+            int n = calls.incrementAndGet();
+            if (n < 2) {
+                org.springframework.web.client.HttpClientErrorException.TooManyRequests t =
+                        new org.springframework.web.client.HttpClientErrorException.TooManyRequests("429");
+                t.withHeader("Retry-After", "0");
+                throw t;
+            }
+            return AgentResult.ofText("ok");
+        };
+
+        // Policy backoff: 10 seconds. Retry-After: 0 must override → run < 1s.
+        RetryPolicy policy = new RetryPolicy(3,
+                Duration.ofSeconds(10), Duration.ofSeconds(10),
+                1.0, 0.0,
+                RetryPredicates.always());
+
+        AgentGraph graph = AgentGraph.builder()
+                .addNode("ratelimited", flaky)
+                .retryPolicy(policy)
+                .build();
+
+        long t0 = System.nanoTime();
+        AgentResult result = graph.invoke(AgentContext.of("go"));
+        long elapsedMs = (System.nanoTime() - t0) / 1_000_000;
+
+        assertThat(result.completed()).isTrue();
+        assertThat(calls.get()).isEqualTo(2);
+        assertThat(elapsedMs)
+                .as("Retry-After:0 must override the 10s policy backoff")
+                .isLessThan(1_000);
+    }
+
+    @Test
+    void customClassifierOverridesDefault() {
+        AtomicInteger calls = new AtomicInteger();
+        Agent broken = ctx -> {
+            calls.incrementAndGet();
+            throw new IllegalArgumentException("would be permanent under default");
+        };
+
+        // Custom classifier treats IllegalArgumentException as TRANSIENT
+        FailureClassifier custom = cause ->
+                cause instanceof IllegalArgumentException
+                        ? FailureClassification.transientFailure()
+                        : null;
+
+        RetryPolicy policy = RetryPolicy.exponential(3, Duration.ZERO)
+                .withClassifier(custom.orElse(FailureClassifier.defaults()));
+
+        AgentGraph graph = AgentGraph.builder()
+                .addNode("broken", broken)
+                .retryPolicy(policy)
+                .build();
+
+        AgentResult result = graph.invoke(AgentContext.of("go"));
+
+        assertThat(result.hasError()).isTrue();
+        assertThat(calls.get()).isEqualTo(3); // custom classifier made it retry
+    }
+
+    @Test
+    void budgetExceededWrappedInRuntimeExceptionStillInterrupts() {
+        Agent overBudget = ctx -> {
+            throw new RuntimeException("wrapper",
+                    new BudgetExceededException("quota burned"));
+        };
+
+        AgentGraph graph = AgentGraph.builder()
+                .addNode("billed", overBudget)
+                .retryPolicy(RetryPolicy.exponential(5, Duration.ZERO))
+                .build();
+
+        AgentResult result = graph.invoke(AgentContext.of("go"));
+
+        assertThat(result.isInterrupted()).isTrue();
+        assertThat(result.interrupt().reason()).isEqualTo("budget.exceeded:billed");
+    }
+}

--- a/agentflow4j-graph/src/test/java/io/github/datallmhub/agentflow4j/graph/FailureClassifierTests.java
+++ b/agentflow4j-graph/src/test/java/io/github/datallmhub/agentflow4j/graph/FailureClassifierTests.java
@@ -1,0 +1,216 @@
+package io.github.datallmhub.agentflow4j.graph;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FailureClassifierTests {
+
+    private final FailureClassifier classifier = FailureClassifier.defaults();
+
+    // ----- JDK transient I/O ---------------------------------------------
+
+    @Test
+    void ioExceptionIsTransient() {
+        FailureClassification c = classifier.classify(new IOException("boom"));
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+        assertThat(c.retryAfter()).isNull();
+    }
+
+    @Test
+    void socketTimeoutIsTransientViaIOException() {
+        FailureClassification c = classifier.classify(new SocketTimeoutException("read"));
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+    }
+
+    @Test
+    void timeoutExceptionIsTransient() {
+        FailureClassification c = classifier.classify(new TimeoutException("slow"));
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+    }
+
+    @Test
+    void plainRuntimeExceptionIsDeclined() {
+        // Unknown exception types are declined (null) so the policy's
+        // retryOn predicate gets the final word — preserves backward compat
+        // for callers that previously relied on `RetryPredicates.always()`.
+        FailureClassification c = classifier.classify(new IllegalArgumentException("nope"));
+        assertThat(c).isNull();
+    }
+
+    @Test
+    void nullCauseIsPermanent() {
+        FailureClassification c = classifier.classify(null);
+        assertThat(c.category()).isEqualTo(FailureCategory.PERMANENT);
+    }
+
+    // ----- Cause chain walking -------------------------------------------
+
+    @Test
+    void unwrapsCompletionExceptionToFindTransientCause() {
+        Throwable wrapped = new CompletionException(new EOFException("eof"));
+        FailureClassification c = classifier.classify(wrapped);
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+    }
+
+    @Test
+    void unwrapsToOverBudgetEvenWhenWrapped() {
+        Throwable wrapped = new RuntimeException("outer",
+                new BudgetExceededException("monthly cap reached"));
+        FailureClassification c = classifier.classify(wrapped);
+        assertThat(c.category()).isEqualTo(FailureCategory.OVER_BUDGET);
+        assertThat(c.reason()).isEqualTo("monthly cap reached");
+    }
+
+    // ----- Budget signal -------------------------------------------------
+
+    @Test
+    void budgetExceededExceptionIsOverBudget() {
+        FailureClassification c = classifier.classify(
+                new BudgetExceededException("monthly cap reached"));
+        assertThat(c.category()).isEqualTo(FailureCategory.OVER_BUDGET);
+        assertThat(c.reason()).isEqualTo("monthly cap reached");
+    }
+
+    @Test
+    void budgetExceededWithoutMessageStillClassifies() {
+        FailureClassification c = classifier.classify(new BudgetExceededException(null));
+        assertThat(c.category()).isEqualTo(FailureCategory.OVER_BUDGET);
+        assertThat(c.reason()).isEqualTo("budget exceeded");
+    }
+
+    // ----- Spring HTTP (via test stubs) ----------------------------------
+
+    @Test
+    void springTooManyRequestsWithoutRetryAfterIsTransient() {
+        Throwable t = new org.springframework.web.client.HttpClientErrorException.TooManyRequests("429");
+        FailureClassification c = classifier.classify(t);
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+        assertThat(c.retryAfter()).isNull();
+    }
+
+    @Test
+    void springTooManyRequestsHonoursRetryAfterSeconds() {
+        org.springframework.web.client.HttpClientErrorException.TooManyRequests t =
+                new org.springframework.web.client.HttpClientErrorException.TooManyRequests("429");
+        t.withHeader("Retry-After", "7");
+        FailureClassification c = classifier.classify(t);
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+        assertThat(c.retryAfter()).isEqualTo(Duration.ofSeconds(7));
+    }
+
+    @Test
+    void springTooManyRequestsWithUnparseableRetryAfterDoesNotCrash() {
+        org.springframework.web.client.HttpClientErrorException.TooManyRequests t =
+                new org.springframework.web.client.HttpClientErrorException.TooManyRequests("429");
+        t.withHeader("Retry-After", "Fri, 31 Dec 2099 23:59:59 GMT"); // HTTP-date form, not parsed in MVP
+        FailureClassification c = classifier.classify(t);
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+        assertThat(c.retryAfter()).isNull(); // falls back to policy backoff
+    }
+
+    @Test
+    void springTooManyRequestsWithNegativeRetryAfterIgnoresIt() {
+        org.springframework.web.client.HttpClientErrorException.TooManyRequests t =
+                new org.springframework.web.client.HttpClientErrorException.TooManyRequests("429");
+        t.withHeader("Retry-After", "-3");
+        FailureClassification c = classifier.classify(t);
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+        assertThat(c.retryAfter()).isNull();
+    }
+
+    @Test
+    void springServerErrorIsTransient() {
+        Throwable t = new org.springframework.web.client.HttpServerErrorException("503");
+        FailureClassification c = classifier.classify(t);
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+    }
+
+    @Test
+    void springClientErrorOtherThan429IsPermanent() {
+        Throwable t = new org.springframework.web.client.HttpClientErrorException.BadRequest("400");
+        FailureClassification c = classifier.classify(t);
+        assertThat(c.category()).isEqualTo(FailureCategory.PERMANENT);
+        assertThat(c.reason()).isEqualTo("HTTP 4xx (non-retryable)");
+    }
+
+    @Test
+    void springResourceAccessExceptionIsTransient() {
+        Throwable t = new org.springframework.web.client.ResourceAccessException("connect refused");
+        FailureClassification c = classifier.classify(t);
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+    }
+
+    // ----- Composition / extensibility -----------------------------------
+
+    @Test
+    void orElseDelegatesWhenFirstReturnsNull() {
+        FailureClassifier custom = cause -> null;          // declines
+        FailureClassifier chain  = custom.orElse(classifier);
+        FailureClassification c = chain.classify(new IOException("x"));
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+    }
+
+    @Test
+    void orElseRespectsFirstClassifierDecision() {
+        FailureClassifier custom = cause ->
+                cause instanceof IllegalStateException
+                        ? FailureClassification.permanent("domain rule")
+                        : null;
+        FailureClassifier chain = custom.orElse(classifier);
+
+        FailureClassification override = chain.classify(new IllegalStateException("x"));
+        assertThat(override.category()).isEqualTo(FailureCategory.PERMANENT);
+        assertThat(override.reason()).isEqualTo("domain rule");
+
+        FailureClassification fallback = chain.classify(new IOException("y"));
+        assertThat(fallback.category()).isEqualTo(FailureCategory.TRANSIENT);
+    }
+
+    // ----- RetryPolicy.classify(...) integration -------------------------
+
+    @Test
+    void retryPolicyClassifyUsesClassifierFirst() {
+        RetryPolicy p = RetryPolicy.exponential(3, Duration.ofMillis(10));
+        FailureClassification c = p.classify(new IOException("x"));
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+    }
+
+    @Test
+    void retryPolicyClassifyFallsBackToRetryOnPredicateWhenClassifierDeclines() {
+        // A classifier that declines everything → falls back to retryOn predicate
+        FailureClassifier declining = cause -> null;
+        RetryPolicy p = new RetryPolicy(3, Duration.ofMillis(10), Duration.ofMillis(100),
+                2.0, 0.0, RetryPredicates.always(), declining);
+
+        FailureClassification c = p.classify(new IllegalArgumentException("x"));
+        assertThat(c.category()).isEqualTo(FailureCategory.TRANSIENT);
+    }
+
+    @Test
+    void retryPolicyClassifyFallsBackToRetryOnFalseWhenClassifierDeclines() {
+        FailureClassifier declining = cause -> null;
+        RetryPolicy p = new RetryPolicy(3, Duration.ofMillis(10), Duration.ofMillis(100),
+                2.0, 0.0, RetryPredicates.never(), declining);
+
+        FailureClassification c = p.classify(new IllegalArgumentException("x"));
+        assertThat(c.category()).isEqualTo(FailureCategory.PERMANENT);
+    }
+
+    @Test
+    void retryPolicyWithClassifierReplacesIt() {
+        RetryPolicy base = RetryPolicy.exponential(3, Duration.ofMillis(10));
+        FailureClassifier custom = cause -> FailureClassification.permanent("custom");
+        RetryPolicy swapped = base.withClassifier(custom);
+
+        assertThat(swapped.classify(new IOException("x")).category())
+                .isEqualTo(FailureCategory.PERMANENT);
+    }
+}

--- a/agentflow4j-graph/src/test/java/org/springframework/web/client/HttpClientErrorException.java
+++ b/agentflow4j-graph/src/test/java/org/springframework/web/client/HttpClientErrorException.java
@@ -1,0 +1,42 @@
+package org.springframework.web.client;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test stub mimicking Spring Web's {@code HttpClientErrorException}.
+ * Only the surface that {@code DefaultFailureClassifier} reflects upon is provided.
+ * <p>This file lives in the test source set so it never reaches production classpath.
+ */
+public class HttpClientErrorException extends RuntimeException {
+
+    private final Map<String, List<String>> headers = new HashMap<>();
+
+    public HttpClientErrorException(String message) {
+        super(message);
+    }
+
+    public Map<String, List<String>> getResponseHeaders() {
+        return headers;
+    }
+
+    public HttpClientErrorException withHeader(String name, String value) {
+        headers.put(name, List.of(value));
+        return this;
+    }
+
+    /** 429 — the only 4xx subtype the classifier treats as TRANSIENT. */
+    public static class TooManyRequests extends HttpClientErrorException {
+        public TooManyRequests(String message) {
+            super(message);
+        }
+    }
+
+    /** Representative non-retryable 4xx subtype. */
+    public static class BadRequest extends HttpClientErrorException {
+        public BadRequest(String message) {
+            super(message);
+        }
+    }
+}

--- a/agentflow4j-graph/src/test/java/org/springframework/web/client/HttpServerErrorException.java
+++ b/agentflow4j-graph/src/test/java/org/springframework/web/client/HttpServerErrorException.java
@@ -1,0 +1,11 @@
+package org.springframework.web.client;
+
+/**
+ * Test stub mimicking Spring Web's {@code HttpServerErrorException} (5xx).
+ * Lives only in the test source set.
+ */
+public class HttpServerErrorException extends RuntimeException {
+    public HttpServerErrorException(String message) {
+        super(message);
+    }
+}

--- a/agentflow4j-graph/src/test/java/org/springframework/web/client/ResourceAccessException.java
+++ b/agentflow4j-graph/src/test/java/org/springframework/web/client/ResourceAccessException.java
@@ -1,0 +1,11 @@
+package org.springframework.web.client;
+
+/**
+ * Test stub mimicking Spring Web's {@code ResourceAccessException} — Spring's
+ * wrapper around low-level I/O failures. Lives only in the test source set.
+ */
+public class ResourceAccessException extends RuntimeException {
+    public ResourceAccessException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
The current RetryPolicy treats all failures the same — a 4xx is retried as often as a 5xx, and an over-budget condition just burns more money. This adds a classification layer so the retry loop can react to *why* a call failed, not just *that* it failed.

- FailureCategory: TRANSIENT / PERMANENT / OVER_BUDGET — three buckets that cover ~95% of real cases without over-engineering.
- FailureClassification: category + optional Retry-After hint + optional reason.
- FailureClassifier (SPI): functional, composable via orElse(...), with a default impl that knows about JDK transient I/O (IOException, TimeoutException), Spring Web HTTP exceptions (5xx + 429 as TRANSIENT — honouring Retry-After via reflection; other 4xx as PERMANENT), and the framework's own BudgetExceededException.
- Detection of Spring exceptions is by class name so agentflow4j-graph keeps no compile-time dependency on Spring. The default classifier returns null (declines) for unknown exception types so the policy's legacy retryOn predicate stays the final word for callers that only set it — fully backward compatible with the existing 92 graph tests.
- AgentGraph's retry loops (sync + streaming) now branch on classification: OVER_BUDGET short-circuits with an InterruptRequest (reason budget.exceeded:<node>) rather than retrying, PERMANENT skips the retry, TRANSIENT honours classification.retryAfter() over the policy's computed backoff when present.

Tests:
- FailureClassifierTests (22 cases) — every category, cause-chain walking, Retry-After parsing (seconds, HTTP-date fallback, negative guard), composition via orElse, RetryPolicy.classify fallback to retryOn predicate.
- AgentGraphReasonAwareRetryTests (8 cases) — OVER_BUDGET emits the right interrupt; PERMANENT 4xx is not retried; TRANSIENT 5xx/429/IOException retries up to maxAttempts; Retry-After:0 overrides a 10s policy backoff; custom classifier composes with the default.
- Spring HTTP detection is exercised via small test stubs in src/test/java/org/springframework/web/client/ — no Spring on the test classpath, the FQN match is verified end-to-end.

Closes #14.