### PR TITLE
Budget-aware fallback in RoutingStrategy (#15)

### DIFF
--- a/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/BudgetPolicy.java
+++ b/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/BudgetPolicy.java
@@ -45,6 +45,22 @@ public interface BudgetPolicy {
     double spent(Scope scope, String nodeName);
 
     /**
+     * Returns the budget remaining at {@code scope} for {@code nodeName}, in
+     * the meter's unit — {@code Double.POSITIVE_INFINITY} when the scope is
+     * unbounded. {@code nodeName} is only consulted for {@link Scope#NODE}.
+     *
+     * <p>Used by routing strategies (e.g. {@code BudgetAwareRouter}) to take
+     * deterministic, cost-aware decisions before invoking the next agent.
+     *
+     * <p>The default implementation returns {@code POSITIVE_INFINITY} so
+     * custom {@link BudgetPolicy} impls stay source-compatible without having
+     * to expose limits.
+     */
+    default double remaining(Scope scope, String nodeName) {
+        return Double.POSITIVE_INFINITY;
+    }
+
+    /**
      * No-op policy. Every call is allowed and no counters are kept.
      * Useful as the default when no budget has been wired.
      */
@@ -59,6 +75,10 @@ public interface BudgetPolicy {
         @Override
         public double spent(Scope scope, String nodeName) {
             return 0.0;
+        }
+        @Override
+        public double remaining(Scope scope, String nodeName) {
+            return Double.POSITIVE_INFINITY;
         }
     };
 

--- a/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/HierarchicalBudgetPolicy.java
+++ b/agentflow4j-graph/src/main/java/io/github/datallmhub/agentflow4j/graph/HierarchicalBudgetPolicy.java
@@ -73,6 +73,20 @@ public final class HierarchicalBudgetPolicy implements BudgetPolicy {
         };
     }
 
+    @Override
+    public double remaining(Scope scope, String nodeName) {
+        double limit = switch (scope) {
+            case RUN  -> limits.perRun();
+            case NODE -> limits.perNode();
+            case CALL -> limits.perCall();
+        };
+        if (Double.isInfinite(limit)) {
+            return Double.POSITIVE_INFINITY;
+        }
+        double left = limit - spent(scope, nodeName);
+        return left < 0.0 ? 0.0 : left;
+    }
+
     public BudgetLimits limits() {
         return limits;
     }

--- a/agentflow4j-samples/src/main/java/io/github/datallmhub/agentflow4j/samples/BudgetAwareRoutingDemo.java
+++ b/agentflow4j-samples/src/main/java/io/github/datallmhub/agentflow4j/samples/BudgetAwareRoutingDemo.java
@@ -1,0 +1,88 @@
+package io.github.datallmhub.agentflow4j.samples;
+
+import io.github.datallmhub.agentflow4j.core.Agent;
+import io.github.datallmhub.agentflow4j.core.AgentContext;
+import io.github.datallmhub.agentflow4j.core.AgentResult;
+import io.github.datallmhub.agentflow4j.graph.BudgetLimits;
+import io.github.datallmhub.agentflow4j.graph.BudgetPolicy;
+import io.github.datallmhub.agentflow4j.graph.CostMeter;
+import io.github.datallmhub.agentflow4j.squad.CoordinatorAgent;
+import io.github.datallmhub.agentflow4j.squad.RoutingStrategy;
+
+/**
+ * 06 — Budget-aware routing.
+ *
+ * <p>Two agents are wired behind a {@link CoordinatorAgent}: a <em>premium</em>
+ * one that simulates an expensive call ($0.50 / call) and a cheap
+ * <em>fallback</em> ($0.02 / call). The router consults the live
+ * {@link BudgetPolicy} and, once the remaining run budget drops below the
+ * configured threshold, switches every subsequent call to the fallback —
+ * deterministically and without paying for any classification.
+ *
+ * <p>Expected output: the first few calls use the premium agent, then the
+ * router silently switches to the fallback as the budget runs down.
+ */
+public final class BudgetAwareRoutingDemo {
+
+    public static void main(String[] args) {
+        System.out.println("=== Budget-Aware Routing ===\n");
+
+        // Two executors, very different cost profiles.
+        Agent premium = ctx -> {
+            System.out.println("  [premium]  expensive call (~$0.50)");
+            return AgentResult.ofText("premium answer");
+        };
+        Agent fallback = ctx -> {
+            System.out.println("  [fallback] cheap call (~$0.02)");
+            return AgentResult.ofText("fallback answer");
+        };
+
+        // A unit-cost meter that returns the latest configured cost. The
+        // executors above don't actually know how much they "cost" — in a
+        // real wiring this would come from AgentResult.usage() via a
+        // CostMeter implementation that maps tokens to dollars.
+        BillingMeter meter = new BillingMeter();
+
+        // RUN budget = $2.00. Switch to fallback once less than $0.40 remains.
+        BudgetPolicy budget = BudgetPolicy.hierarchical(
+                BudgetLimits.builder().perRun(2.00).build(),
+                /* estimator: not used by this demo */ (node, ctx) -> 0.0,
+                meter);
+
+        RoutingStrategy router = RoutingStrategy.budgetAware(
+                budget, BudgetPolicy.Scope.RUN, /* threshold */ 0.40,
+                "premium", "fallback");
+
+        CoordinatorAgent coordinator = CoordinatorAgent.builder()
+                .executor("premium", premium)
+                .executor("fallback", fallback)
+                .routingStrategy(router)
+                .build();
+
+        // Six requests; pricing per request alternates based on which executor
+        // the router picks. We record cost manually after each call to
+        // simulate the graph's "record after attempt" flow without a full
+        // AgentGraph wiring (kept simple for the demo).
+        for (int i = 1; i <= 6; i++) {
+            System.out.printf("Request #%d (remaining: $%.2f)%n", i,
+                    budget.remaining(BudgetPolicy.Scope.RUN, "premium"));
+            AgentResult result = coordinator.execute(
+                    AgentContext.of("answer me " + i));
+            // Charge the cost matching the executor that ran.
+            double cost = result.text().startsWith("premium") ? 0.50 : 0.02;
+            meter.nextCost(cost);
+            budget.record(/* nodeName */ "any", result);
+            System.out.println();
+        }
+
+        System.out.printf("Final remaining: $%.2f%n",
+                budget.remaining(BudgetPolicy.Scope.RUN, "premium"));
+    }
+
+    /** Test-only meter — returns the cost set by the last {@code nextCost(...)} call. */
+    private static final class BillingMeter implements CostMeter {
+        private double next = 0.0;
+        void nextCost(double v) { this.next = v; }
+        @Override public double measure(String nodeName, AgentResult result) { return next; }
+    }
+}

--- a/agentflow4j-squad/src/main/java/io/github/datallmhub/agentflow4j/squad/BudgetAwareRouter.java
+++ b/agentflow4j-squad/src/main/java/io/github/datallmhub/agentflow4j/squad/BudgetAwareRouter.java
@@ -1,0 +1,107 @@
+package io.github.datallmhub.agentflow4j.squad;
+
+import java.util.Objects;
+import java.util.Set;
+
+import io.github.datallmhub.agentflow4j.core.AgentContext;
+import io.github.datallmhub.agentflow4j.graph.BudgetPolicy;
+
+/**
+ * Deterministic, cost-aware {@link RoutingStrategy} that routes to a
+ * <em>premium</em> agent while there is budget remaining, and switches to a
+ * cheaper <em>fallback</em> agent once the remaining budget at a configured
+ * {@link BudgetPolicy.Scope scope} falls below a threshold.
+ *
+ * <p>This is the one cost-aware routing lever that is both <em>deterministic</em>
+ * and <em>provably cheaper</em>: classifying complexity ex-ante via an LLM
+ * would already cost a call (chicken-and-egg), and self-confidence routing
+ * doubles the cost. Reading the live {@link BudgetPolicy} counters is free.
+ *
+ * <p>Typical wiring:
+ *
+ * <pre>{@code
+ * BudgetPolicy budget = BudgetPolicy.hierarchical(
+ *         BudgetLimits.builder().perRun(5.00).build(),
+ *         estimator, meter);
+ *
+ * RoutingStrategy router = RoutingStrategy.budgetAware(
+ *         budget, BudgetPolicy.Scope.RUN, 1.00, "premium", "fallback");
+ *
+ * // The graph and the router share the same BudgetPolicy instance so the
+ * // router sees live spend.
+ * }</pre>
+ */
+public final class BudgetAwareRouter implements RoutingStrategy {
+
+    private final BudgetPolicy budgetPolicy;
+    private final BudgetPolicy.Scope scope;
+    private final double threshold;
+    private final String premiumExecutor;
+    private final String fallbackExecutor;
+
+    /**
+     * @param budgetPolicy     the live policy whose remaining counters drive
+     *                         the routing decision; must be the same instance
+     *                         wired into the graph.
+     * @param scope            the scope to consult — typically
+     *                         {@link BudgetPolicy.Scope#RUN}.
+     * @param threshold        switch to {@code fallbackExecutor} once
+     *                         {@code remaining < threshold} (strictly less);
+     *                         must be {@code >= 0}.
+     * @param premiumExecutor  the executor name to prefer while budget allows.
+     * @param fallbackExecutor the executor name to use once the threshold is crossed.
+     */
+    public BudgetAwareRouter(BudgetPolicy budgetPolicy,
+                             BudgetPolicy.Scope scope,
+                             double threshold,
+                             String premiumExecutor,
+                             String fallbackExecutor) {
+        this.budgetPolicy = Objects.requireNonNull(budgetPolicy, "budgetPolicy");
+        this.scope = Objects.requireNonNull(scope, "scope");
+        if (threshold < 0.0 || Double.isNaN(threshold)) {
+            throw new IllegalArgumentException("threshold must be >= 0 (was " + threshold + ")");
+        }
+        this.threshold = threshold;
+        this.premiumExecutor = Objects.requireNonNull(premiumExecutor, "premiumExecutor");
+        this.fallbackExecutor = Objects.requireNonNull(fallbackExecutor, "fallbackExecutor");
+        if (premiumExecutor.equals(fallbackExecutor)) {
+            throw new IllegalArgumentException(
+                    "premiumExecutor and fallbackExecutor must differ (was both '"
+                            + premiumExecutor + "')");
+        }
+    }
+
+    @Override
+    public String selectExecutor(AgentContext context, Set<String> availableExecutors) {
+        if (!availableExecutors.contains(premiumExecutor)) {
+            throw new IllegalStateException(
+                    "Premium executor not registered: '" + premiumExecutor + "'");
+        }
+        if (!availableExecutors.contains(fallbackExecutor)) {
+            throw new IllegalStateException(
+                    "Fallback executor not registered: '" + fallbackExecutor + "'");
+        }
+        double remaining = budgetPolicy.remaining(scope, premiumExecutor);
+        return remaining < threshold ? fallbackExecutor : premiumExecutor;
+    }
+
+    /** Exposed for tests and observability. */
+    public double threshold() {
+        return threshold;
+    }
+
+    /** Exposed for tests and observability. */
+    public BudgetPolicy.Scope scope() {
+        return scope;
+    }
+
+    /** Exposed for tests and observability. */
+    public String premiumExecutor() {
+        return premiumExecutor;
+    }
+
+    /** Exposed for tests and observability. */
+    public String fallbackExecutor() {
+        return fallbackExecutor;
+    }
+}

--- a/agentflow4j-squad/src/main/java/io/github/datallmhub/agentflow4j/squad/RoutingStrategy.java
+++ b/agentflow4j-squad/src/main/java/io/github/datallmhub/agentflow4j/squad/RoutingStrategy.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import io.github.datallmhub.agentflow4j.core.Agent;
 import io.github.datallmhub.agentflow4j.core.AgentContext;
+import io.github.datallmhub.agentflow4j.graph.BudgetPolicy;
 import org.springframework.ai.chat.client.ChatClient;
 
 @FunctionalInterface
@@ -31,6 +32,20 @@ public interface RoutingStrategy {
 
     static RoutingStrategy llmDriven(ChatClient chatClient) {
         return new LlmRoutingStrategy(chatClient);
+    }
+
+    /**
+     * Deterministic, cost-aware routing: send work to {@code premium} while
+     * the remaining budget at {@code scope} is {@code >= threshold}, and
+     * switch to {@code fallback} once it drops below. See
+     * {@link BudgetAwareRouter} for the full rationale and wiring.
+     */
+    static RoutingStrategy budgetAware(BudgetPolicy budget,
+                                       BudgetPolicy.Scope scope,
+                                       double threshold,
+                                       String premium,
+                                       String fallback) {
+        return new BudgetAwareRouter(budget, scope, threshold, premium, fallback);
     }
 
     /**

--- a/agentflow4j-squad/src/test/java/io/github/datallmhub/agentflow4j/squad/BudgetAwareRouterTests.java
+++ b/agentflow4j-squad/src/test/java/io/github/datallmhub/agentflow4j/squad/BudgetAwareRouterTests.java
@@ -1,0 +1,214 @@
+package io.github.datallmhub.agentflow4j.squad;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.github.datallmhub.agentflow4j.core.AgentContext;
+import io.github.datallmhub.agentflow4j.core.AgentResult;
+import io.github.datallmhub.agentflow4j.graph.BudgetLimits;
+import io.github.datallmhub.agentflow4j.graph.BudgetPolicy;
+import io.github.datallmhub.agentflow4j.graph.CostMeter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BudgetAwareRouterTests {
+
+    private static final Set<String> BOTH = Set.of("premium", "fallback");
+
+    // ----- Construction / validation -------------------------------------
+
+    @Test
+    void rejectsNegativeThreshold() {
+        assertThatThrownBy(() -> new BudgetAwareRouter(
+                BudgetPolicy.NOOP, BudgetPolicy.Scope.RUN, -0.01, "premium", "fallback"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("threshold must be >= 0");
+    }
+
+    @Test
+    void rejectsNaNThreshold() {
+        assertThatThrownBy(() -> new BudgetAwareRouter(
+                BudgetPolicy.NOOP, BudgetPolicy.Scope.RUN, Double.NaN, "premium", "fallback"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejectsIdenticalPremiumAndFallback() {
+        assertThatThrownBy(() -> new BudgetAwareRouter(
+                BudgetPolicy.NOOP, BudgetPolicy.Scope.RUN, 1.0, "same", "same"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must differ");
+    }
+
+    // ----- Decision: in-budget vs exhausted ------------------------------
+
+    @Test
+    void routesToPremiumWhenBudgetIsHealthy() {
+        BudgetPolicy budget = newRunBudget(/* limit */ 5.00);
+        // 0 spent → remaining = 5.00 ≥ threshold 1.00
+        RoutingStrategy router = RoutingStrategy.budgetAware(
+                budget, BudgetPolicy.Scope.RUN, 1.00, "premium", "fallback");
+
+        assertThat(router.selectExecutor(AgentContext.empty(), BOTH)).isEqualTo("premium");
+    }
+
+    @Test
+    void routesToFallbackWhenBudgetDropsBelowThreshold() {
+        BudgetPolicy budget = newRunBudget(5.00);
+        spend(budget, "premium", 4.50); // remaining = 0.50 < 1.00
+
+        RoutingStrategy router = RoutingStrategy.budgetAware(
+                budget, BudgetPolicy.Scope.RUN, 1.00, "premium", "fallback");
+
+        assertThat(router.selectExecutor(AgentContext.empty(), BOTH)).isEqualTo("fallback");
+    }
+
+    @Test
+    void thresholdComparisonIsStrictlyLess() {
+        // remaining EXACTLY equals threshold → still premium (strictly less switches)
+        BudgetPolicy budget = newRunBudget(5.00);
+        spend(budget, "premium", 4.00); // remaining = 1.00, threshold = 1.00
+
+        RoutingStrategy router = RoutingStrategy.budgetAware(
+                budget, BudgetPolicy.Scope.RUN, 1.00, "premium", "fallback");
+
+        assertThat(router.selectExecutor(AgentContext.empty(), BOTH)).isEqualTo("premium");
+    }
+
+    @Test
+    void noopBudgetAlwaysPremium() {
+        // POSITIVE_INFINITY remaining → router never falls back
+        RoutingStrategy router = RoutingStrategy.budgetAware(
+                BudgetPolicy.NOOP, BudgetPolicy.Scope.RUN,
+                Double.MAX_VALUE / 2, "premium", "fallback");
+
+        assertThat(router.selectExecutor(AgentContext.empty(), BOTH)).isEqualTo("premium");
+    }
+
+    @Test
+    void zeroThresholdOnlyFallsBackWhenBudgetIsNegativeOrExhausted() {
+        BudgetPolicy budget = newRunBudget(5.00);
+        spend(budget, "premium", 5.00); // remaining = 0.00, threshold = 0.00 → not less → premium
+
+        RoutingStrategy router = RoutingStrategy.budgetAware(
+                budget, BudgetPolicy.Scope.RUN, 0.00, "premium", "fallback");
+
+        assertThat(router.selectExecutor(AgentContext.empty(), BOTH)).isEqualTo("premium");
+    }
+
+    // ----- Live behaviour: routing shifts as spend accumulates -----------
+
+    @Test
+    void switchesFromPremiumToFallbackAsSpendAccumulates() {
+        BudgetPolicy budget = newRunBudget(2.00);
+        RoutingStrategy router = RoutingStrategy.budgetAware(
+                budget, BudgetPolicy.Scope.RUN, 0.50, "premium", "fallback");
+
+        // Start: 0 spent, remaining = 2.00 → premium
+        assertThat(router.selectExecutor(AgentContext.empty(), BOTH)).isEqualTo("premium");
+
+        spend(budget, "premium", 1.00); // remaining = 1.00 ≥ 0.50 → still premium
+        assertThat(router.selectExecutor(AgentContext.empty(), BOTH)).isEqualTo("premium");
+
+        spend(budget, "premium", 0.60); // remaining = 0.40 < 0.50 → fallback
+        assertThat(router.selectExecutor(AgentContext.empty(), BOTH)).isEqualTo("fallback");
+    }
+
+    @Test
+    void nodeScopeThresholdConsultsPerNodeSpend() {
+        BudgetPolicy budget = BudgetPolicy.hierarchical(
+                BudgetLimits.builder().perNode(1.00).build(),
+                (node, ctx) -> 0.0,
+                CostMeter.perCall());
+
+        // Spend 0.80 on the 'premium' node specifically.
+        for (int i = 0; i < 8; i++) {
+            budget.record("premium", AgentResult.ofText("ok"));
+        }
+        // Remaining for 'premium' at NODE = 1.00 - 0.80 = 0.20 < 0.50 → fallback
+        RoutingStrategy router = RoutingStrategy.budgetAware(
+                budget, BudgetPolicy.Scope.NODE, 0.50, "premium", "fallback");
+        assertThat(router.selectExecutor(AgentContext.empty(), BOTH)).isEqualTo("fallback");
+    }
+
+    // ----- Missing executors --------------------------------------------
+
+    @Test
+    void throwsWhenPremiumIsNotAvailable() {
+        RoutingStrategy router = RoutingStrategy.budgetAware(
+                BudgetPolicy.NOOP, BudgetPolicy.Scope.RUN, 1.0, "premium", "fallback");
+        assertThatThrownBy(() ->
+                router.selectExecutor(AgentContext.empty(), Set.of("fallback")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Premium executor not registered");
+    }
+
+    @Test
+    void throwsWhenFallbackIsNotAvailable() {
+        RoutingStrategy router = RoutingStrategy.budgetAware(
+                BudgetPolicy.NOOP, BudgetPolicy.Scope.RUN, 1.0, "premium", "fallback");
+        assertThatThrownBy(() ->
+                router.selectExecutor(AgentContext.empty(), Set.of("premium")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Fallback executor not registered");
+    }
+
+    // ----- BudgetPolicy.remaining contract -------------------------------
+
+    @Test
+    void hierarchicalRemainingClampsAtZeroAfterOverspend() {
+        BudgetPolicy budget = newRunBudget(1.00);
+        spend(budget, "any", 1.50); // overshoot
+        assertThat(budget.remaining(BudgetPolicy.Scope.RUN, "any")).isEqualTo(0.0);
+    }
+
+    @Test
+    void hierarchicalRemainingReturnsInfinityForUnboundedScope() {
+        BudgetPolicy budget = BudgetPolicy.hierarchical(
+                BudgetLimits.run(1.00),   // perRun bounded, perNode + perCall unbounded
+                (node, ctx) -> 0.0,
+                CostMeter.perCall());
+        assertThat(budget.remaining(BudgetPolicy.Scope.NODE, "x"))
+                .isEqualTo(Double.POSITIVE_INFINITY);
+        assertThat(budget.remaining(BudgetPolicy.Scope.CALL, "x"))
+                .isEqualTo(Double.POSITIVE_INFINITY);
+    }
+
+    @Test
+    void customBudgetPolicyDefaultsRemainingToInfinity() {
+        BudgetPolicy custom = new BudgetPolicy() {
+            @Override public Decision check(String node, AgentContext ctx) { return Decision.allow(); }
+            @Override public void record(String node, AgentResult result) {}
+            @Override public double spent(Scope scope, String node) { return 0; }
+        };
+        assertThat(custom.remaining(BudgetPolicy.Scope.RUN, "x"))
+                .isEqualTo(Double.POSITIVE_INFINITY);
+    }
+
+    // ----- Helpers -------------------------------------------------------
+
+    /** Builds a RUN-bounded hierarchical budget using a unit-cost meter. */
+    private static BudgetPolicy newRunBudget(double perRun) {
+        return BudgetPolicy.hierarchical(
+                BudgetLimits.run(perRun),
+                /* estimator */ (node, ctx) -> 0.0,
+                /* meter     */ new FixedCostMeter());
+    }
+
+    /** Forces a known cost to be recorded against {@code node}. */
+    private static void spend(BudgetPolicy budget, String node, double amount) {
+        FixedCostMeter.NEXT_COST.set(amount);
+        budget.record(node, AgentResult.ofText("done"));
+        FixedCostMeter.NEXT_COST.set(0.0);
+    }
+
+    /** Test {@link CostMeter} that returns whatever the latest call set. */
+    private static final class FixedCostMeter implements CostMeter {
+        static final AtomicReference<Double> NEXT_COST = new AtomicReference<>(0.0);
+        @Override public double measure(String nodeName, AgentResult result) {
+            return NEXT_COST.get();
+        }
+    }
+}


### PR DESCRIPTION
Cost-aware routing is usually pitched as "use a cheaper model on simple inputs, a stronger one on complex ones" — but classifying complexity ex-ante costs an LLM call (chicken-and-egg), and self-confidence routing doubles the cost. The one lever that is both deterministic and provably cheaper: switch to a fallback agent once the remaining budget falls below a threshold.

- BudgetPolicy gains a default `remaining(scope, nodeName)` method that returns POSITIVE_INFINITY when unbounded; HierarchicalBudgetPolicy overrides it as `max(0, limit - spent)` per scope. NOOP also overrides to POSITIVE_INFINITY explicitly. The default is backward-compatible — custom BudgetPolicy impls do not have to expose limits.

- BudgetAwareRouter is a new RoutingStrategy that consults the live BudgetPolicy and routes to a designated fallback once `remaining < threshold` (strictly less). It validates that both the premium and fallback executors are registered before the run.

- RoutingStrategy.budgetAware(...) static factory wires it cleanly:

      RoutingStrategy router = RoutingStrategy.budgetAware(
              budget, BudgetPolicy.Scope.RUN, 0.40, "premium", "fallback");

- Sample: BudgetAwareRoutingDemo wires a premium executor ($0.50/call) and a cheap fallback ($0.02/call) behind a CoordinatorAgent, with a $2.00 RUN budget and a $0.40 switch threshold. Output shows the router silently transitioning from premium to fallback as spend accumulates.

Tests (BudgetAwareRouterTests, 16 cases):
- in-budget routes to premium; exhausted routes to fallback
- threshold comparison is strictly less (`remaining == threshold` → premium)
- NOOP budget (POSITIVE_INFINITY remaining) → always premium
- live switch as spend accumulates across calls
- NODE-scope threshold consults per-node spend
- missing premium or fallback throws IllegalStateException
- constructor rejects negative / NaN threshold and identical executor names
- HierarchicalBudgetPolicy.remaining clamps at zero on overshoot
- HierarchicalBudgetPolicy.remaining returns POSITIVE_INFINITY on unbounded scopes
- custom BudgetPolicy impls inherit POSITIVE_INFINITY by default

Full repo build is green; graph (96 tests) and squad (64 tests) suites remain all-green; no API breaks downstream.

Closes #15.