### PR TITLE
Bump Spring Boot, Spring AI and AssertJ to clear Dependabot alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,12 +39,12 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-boot.version>3.3.0</spring-boot.version>
-        <spring-ai.version>1.0.0</spring-ai.version>
+        <spring-boot.version>3.3.13</spring-boot.version>
+        <spring-ai.version>1.0.7</spring-ai.version>
         <resilience4j.version>2.2.0</resilience4j.version>
 
         <junit.version>5.10.2</junit.version>
-        <assertj.version>3.25.3</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <mockito.version>5.11.0</mockito.version>
     </properties>
 


### PR DESCRIPTION
Addresses the open Dependabot alerts. Most were duplicates of the same advisory across modules; deduplicated, they trace back to two pinned BOMs (Spring Boot 3.3.0, Spring AI 1.0.0) and an old AssertJ.

## Changes (parent `pom.xml`)

| Dependency | From | To | Clears |
|---|---|---|---|
| `spring-ai` | 1.0.0 | **1.0.7** | 3× HIGH — ChatMemory cross-user data leak, prompt injection via memory poisoning |
| `spring-boot` | 3.3.0 | **3.3.13** | HIGH EndpointRequest matcher + patched transitives via BOM (spring-context DataBinder, etc.) |
| `assertj` | 3.25.3 | **3.27.7** | HIGH XXE (test scope only) |

The three Spring AI advisories are the most relevant — they're `ChatMemory` / prompt-injection issues, directly in the path of an agent framework that markets governance and safety.

## Scope

Stays within the **3.3.x line** to keep the change low-risk ahead of 1.0 (patch-level Spring Boot + Spring AI bumps; AssertJ is test-only).

## Not covered here (need a later Spring Boot 3.4+/Spring AI 2.0 migration)

Two advisories have **no fix in the current minor lines** ("fixed in n/a"):
- `spring-core` improper authorization (≤ 6.1.22)
- `spring-boot` predictable temp directory (≤ 3.3.18)

Both are resolved by the Spring Boot 3.4+/Spring AI 2.0 upgrade already on the roadmap; folding them in here would widen the change surface right before 1.0.

## Verification

- Full `mvn clean install` green across every module (graph, squad, checkpoint, resilience4j, cli-agents, starter, playground, samples).
- The `MISTRAL_API_KEY`-gated `MistralIntegrationTests` skip as designed when no live key is present (7 skipped).

## Note (out of scope)

`MistralIntegrationTests` is gated with `@EnabledIfEnvironmentVariable(matches = ".+")`, which a placeholder value (e.g. `your-mistral-api-key-here`) satisfies — causing live tests to run against the API with an invalid key. Tightening that gate is a separate test-quality fix, not part of this security bump.