### PR TITLE
Pin patched transitive deps to clear remaining Dependabot alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,51 @@
         <junit.version>5.10.2</junit.version>
         <assertj.version>3.27.7</assertj.version>
         <mockito.version>5.11.0</mockito.version>
+
+        <!-- Security overrides: these fix versions are newer than the Spring
+             Boot 3.3.x BOM pins. Because we import the Boot BOM (rather than
+             inherit spring-boot-starter-parent), version-property overrides
+             do not apply — they must be pinned explicitly in
+             dependencyManagement, ahead of the BOM import, so they win. -->
+        <jackson-bom.override.version>2.18.6</jackson-bom.override.version>
+        <logback.override.version>1.5.25</logback.override.version>
+        <xmlunit.override.version>2.10.0</xmlunit.override.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- Security overrides — declared BEFORE the Spring Boot BOM so
+                 they take precedence over the versions it manages. Each fixes
+                 a Dependabot advisory whose patched version the 3.3.x BOM does
+                 not yet pin. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-bom.override.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.xmlunit</groupId>
+                <artifactId>xmlunit-core</artifactId>
+                <version>${xmlunit.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
PR #21 bumped the Spring Boot / Spring AI / AssertJ versions, but several advisories stayed open because:

1. The project imports the Spring Boot BOM (it does not inherit spring-boot-starter-parent), so version-property overrides such as <assertj.version> are ignored — the BOM keeps winning. AssertJ stayed at 3.25.3 despite the property saying 3.27.7.
2. The patched versions for jackson, logback and xmlunit are newer than anything the Spring Boot 3.3.x BOM pins, so no Boot 3.3.x bump can reach them.

Fix: pin the patched versions explicitly in dependencyManagement, declared ahead of the spring-boot-dependencies import so they take precedence.

- jackson-bom 2.18.6 (imported, keeps jackson-core/databind aligned) — clears the jackson-core async-parser DoS.
- logback-core + logback-classic 1.5.25 — clears the logback EL-injection / code-exec advisories.
- xmlunit-core 2.10.0 (test scope) — clears the XSLT insecure-defaults advisory.
- assertj-core 3.27.7 pinned explicitly (the property alone had no effect) — clears the XXE advisory.

Verified via dependency:tree: jackson 2.18.6, logback 1.5.25, xmlunit 2.10.0, assertj 3.27.7 all resolve. Full clean build + test suite green.

Still requires a later Spring Boot 3.4+/Spring AI 2.0 migration (no fix in the 6.1.x / 3.3.x lines): spring-core improper-authorization and spring-boot predictable-temp-directory.