### PR TITLE
Pin tomcat + thymeleaf to clear web-stack Dependabot alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,10 @@
         <jackson-bom.override.version>2.18.6</jackson-bom.override.version>
         <logback.override.version>1.5.25</logback.override.version>
         <xmlunit.override.version>2.10.0</xmlunit.override.version>
+        <!-- Web stack: pulled in by the playground (web app) and samples.
+             Boot 3.3.x pins older tomcat/thymeleaf than the latest CVE fixes. -->
+        <tomcat.override.version>10.1.55</tomcat.override.version>
+        <thymeleaf.override.version>3.1.5.RELEASE</thymeleaf.override.version>
     </properties>
 
     <dependencyManagement>
@@ -89,6 +93,31 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.thymeleaf</groupId>
+                <artifactId>thymeleaf</artifactId>
+                <version>${thymeleaf.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.thymeleaf</groupId>
+                <artifactId>thymeleaf-spring6</artifactId>
+                <version>${thymeleaf.override.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The bulk of the open alerts were concentrated in the two web modules — agentflow4j-playground (embedded web app) and agentflow4j-samples — not in the published library modules, which carry only a handful. They came from the Spring Boot 3.3.x BOM pinning older tomcat-embed and thymeleaf than the latest CVE fixes.

Pinned ahead of the Boot BOM (same approach as the jackson/logback overrides):

- tomcat-embed-core / -el / -websocket 10.1.55 — clears ~15 high/critical tomcat advisories (kept the three embed artifacts aligned).
- thymeleaf / thymeleaf-spring6 3.1.5.RELEASE — clears the critical template-injection (RCE-class) advisories.

Verified via dependency:tree: tomcat 10.1.55 and thymeleaf 3.1.5.RELEASE resolve in playground + samples. Full clean build green, including the playground integration tests that exercise the embedded Tomcat.

Remaining open advisories all have no fix in the current minor lines and need the Spring Boot 3.4+/Spring AI 2.0 migration already on the roadmap: spring-core improper-authorization, spring-boot predictable-temp-dir, and a few low/medium spring-webmvc/spring-webflux items.