### PR TITLE
Upgrade Spring Boot 3.3.13 -> 3.4.13 to clear the remaining Dependabo…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-boot.version>3.3.13</spring-boot.version>
+        <spring-boot.version>3.4.13</spring-boot.version>
         <spring-ai.version>1.0.7</spring-ai.version>
         <resilience4j.version>2.2.0</resilience4j.version>
 


### PR DESCRIPTION
…t alerts

After the earlier override PRs the alert count fell to 28, but all 28 had no fix available in the 3.3.x / Spring Framework 6.1.x lines — they could not be cleared with version overrides. They all required Spring Framework 6.2.x, which ships with Spring Boot 3.4+.

- spring-boot 3.3.13 -> 3.4.13 (brings Spring Framework 6.2.15).
- Clears: spring-core improper-authorization (<= 6.1.22), spring-boot predictable-temp-directory (<= 3.3.18), and the low/medium spring-webmvc / spring-webflux advisories — all now resolve on 6.2.15 / 3.4.13, outside their vulnerable ranges.

Spring AI 1.0.7 runs unchanged on Boot 3.4.13. Full clean build + every test suite green, including the playground integration tests (embedded Tomcat) and the autoconfigure starter tests — no Boot 3.3 -> 3.4 migration breakage.

The explicit security pins from the prior PRs (jackson, logback, tomcat, thymeleaf, xmlunit, assertj) are kept as forward-pins; some may now be redundant under the 3.4.x BOM but are harmless and can be trimmed later.