### PR TITLE
Bump Spring Framework to 6.2.18 + add Dependabot auto-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # Maven dependencies across the whole multi-module reactor.
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # Group the Spring ecosystem so a Boot/Framework/AI bump arrives as one PR
+      # instead of a dozen — most security advisories here move together.
+      spring:
+        patterns:
+          - "org.springframework"
+          - "org.springframework.*"
+          - "org.springframework.boot:*"
+          - "org.springframework.ai:*"
+      # Server / templating stack pulled in by the playground + samples.
+      web-runtime:
+        patterns:
+          - "org.apache.tomcat.embed:*"
+          - "org.thymeleaf:*"
+          - "ch.qos.logback:*"
+      # Test + build tooling.
+      test-tooling:
+        patterns:
+          - "org.junit.*"
+          - "org.assertj:*"
+          - "org.mockito:*"
+
+  # Keep GitHub Actions workflows (docs site deploy, CI) current.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,9 @@
              Boot 3.3.x pins older tomcat/thymeleaf than the latest CVE fixes. -->
         <tomcat.override.version>10.1.55</tomcat.override.version>
         <thymeleaf.override.version>3.1.5.RELEASE</thymeleaf.override.version>
+        <!-- Spring Framework: Boot 3.4.13 pins 6.2.15; bump to 6.2.18 to clear
+             the spring-webmvc / spring-webflux advisories (fixed in 6.2.18). -->
+        <spring-framework.override.version>6.2.18</spring-framework.override.version>
     </properties>
 
     <dependencyManagement>
@@ -118,6 +121,13 @@
                 <groupId>org.thymeleaf</groupId>
                 <artifactId>thymeleaf-spring6</artifactId>
                 <version>${thymeleaf.override.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>${spring-framework.override.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
After the Boot 3.4.13 upgrade the rescan surfaced a new batch of advisories against Spring Framework 6.2.x. This clears the fixable ones and automates future maintenance so it stops being manual firefighting.

- spring-framework-bom 6.2.18 pinned ahead of the Boot BOM (Boot 3.4.13 pins 6.2.15). Clears the spring-webmvc / spring-webflux advisories — Script View Templates path limitation, static-resource DoS, SSE stream corruption, static-resource cache poisoning — all fixed in 6.2.18.
- .github/dependabot.yml: weekly grouped version-update PRs (Spring, web-runtime, test-tooling) + GitHub Actions, so dependency bumps arrive automatically instead of being chased by hand.

Verified: spring-core/context/webmvc/webflux all resolve to 6.2.18. Full clean build + test suite green.

Not fixable by any bump right now: the spring-boot "predictable temp directory" advisory affects the entire 3.4.x line (>= 3.4.0, <= 3.4.15) with no patched version published (fix=n/a). It carries low real-world impact (predictable temp dir, local attacker) and should be dismissed as "no fix available — awaiting upstream" until Spring ships one.