### PR TITLE
Revert accidental Spring Boot 4 / Spring AI 1.1 major bump (broke main)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-boot.version>4.0.6</spring-boot.version>
-        <spring-ai.version>1.1.7</spring-ai.version>
+        <spring-boot.version>3.4.13</spring-boot.version>
+        <spring-ai.version>1.0.7</spring-ai.version>
         <resilience4j.version>2.2.0</resilience4j.version>
 
         <junit.version>5.10.2</junit.version>


### PR DESCRIPTION
A Dependabot "spring group" PR (created by the initial dependabot.yml before it was hardened to ignore majors) bundled a MAJOR jump — spring-boot 3.4.13 -> 4.0.6 and spring-ai 1.0.7 -> 1.1.7 — and was merged. That left main uncompilable: the spring-framework override still pinned 6.2.x against a Boot 4 BOM, and the Spring AI 1.1 API changed (AssistantMessage / ToolResponseMessage constructors) so agentflow4j-checkpoint no longer built.

Revert to the known-good combo:
- spring-boot 4.0.6 -> 3.4.13
- spring-ai 1.1.7 -> 1.0.7

Full clean build + every module green again. The Boot 4 / Spring AI 1.1+ upgrade is a deliberate migration to be done on its own, not via an auto-merged dependency bump. The hardened dependabot.yml (already on main) now ignores major updates so this cannot recur.