### PR TITLE
chore: stop Dependabot proposing breaking Spring AI minor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,17 @@ updates:
           - minor
           - patch
     ignore:
+      # No automatic major bumps anywhere — Boot 4 / Spring Framework 7 /
+      # Spring AI 2.0 are deliberate, hand-driven migrations.
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # Spring AI changes its public API on MINOR bumps (1.0 -> 1.1 broke the
+      # checkpoint codec's AssistantMessage / ToolResponseMessage usage), so
+      # only patch updates (1.0.x) are allowed automatically; minor is manual.
+      - dependency-name: "org.springframework.ai:*"
+        update-types:
+          - "version-update:semver-minor"
 
   # GitHub Actions, also grouped into one PR.
   - package-ecosystem: github-actions


### PR DESCRIPTION
The grouped Maven PR kept failing CI because it bundled spring-ai 1.0.7 -> 1.1.7. Spring AI changes its public API on MINOR versions (1.0 -> 1.1 removed the AssistantMessage / ToolResponseMessage constructors the checkpoint codec relies on), so a minor bump breaks the build.

Ignore minor updates for org.springframework.ai:* — only patch (1.0.x) is automatic now; minor/major are deliberate manual migrations. Spring Boot minor stays allowed (3.5.x builds clean and fixes the temp-dir advisory).