### PR TITLE
Pin tomcat-embed 10.1.55 to clear critical tomcat advisories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,34 @@
         <junit.version>5.10.2</junit.version>
         <assertj.version>3.27.7</assertj.version>
         <mockito.version>5.11.0</mockito.version>
+
+        <!-- Single security pin: Boot 3.5.14 ships tomcat 10.1.54, one patch
+             behind the fix (10.1.55) for several critical/high tomcat-embed
+             advisories. Same 10.1.x line — drop this once Boot pins 10.1.55+. -->
+        <tomcat.version>10.1.55</tomcat.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- Security pin ahead of the Boot BOM: tomcat 10.1.55 fixes
+                 critical/high tomcat-embed advisories that 10.1.54 (Boot 3.5.14's
+                 default) is still exposed to. Stays on the 10.1.x line. -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
Spring Boot 3.5.14 ships tomcat-embed 10.1.54, one patch behind the fix for several critical/high tomcat-embed-core advisories (all need 10.1.55). The 14 open alerts were entirely this, concentrated in the playground + samples web modules.

Pin tomcat-embed core/el/websocket to 10.1.55 ahead of the Boot BOM — same 10.1.x line, a single patch bump, no major-version mismatch. This is the one override Boot 3.5.14's BOM doesn't yet cover; drop it once Boot pins 10.1.55+.

dependency:tree confirms 10.1.55 resolves; full build + test suite green including the playground integration tests (embedded Tomcat).