### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions on the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+# Least-privilege GITHUB_TOKEN: the build only needs to read the repo.
+# Artifact upload uses the run's own storage and needs no repo write scope.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CodeQL flagged build.yml for not restricting the GITHUB_TOKEN. The build job only checks out the repo and runs the Maven build; artifact upload uses the run's own storage, so no write scope is needed.

Add an explicit top-level `permissions: contents: read`. (docs.yml already declares its required pages/id-token scopes.)