### PR TITLE
release: bump version to 0.7.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ Describe the bug clearly and concisely.
 
 ## Version
 
-- AgentFlow4J version: <!-- e.g. v0.6.0 -->
+- AgentFlow4J version: <!-- e.g. v0.7.0 -->
 - Java version: <!-- Java 17+ -->
 - Maven version:
 - Spring Boot version: <!-- Spring Boot 3.x -->

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Distributed via [JitPack](https://jitpack.io).
 <dependency>
     <groupId>com.github.datallmhub.agentflow4j</groupId>
     <artifactId>agentflow4j-starter</artifactId>
-    <version>v0.6.0</version>
+    <version>v0.7.0</version>
 </dependency>
 ```
 
@@ -152,7 +152,7 @@ Distributed via [JitPack](https://jitpack.io).
 
 ```groovy
 repositories { maven { url 'https://jitpack.io' } }
-dependencies { implementation 'com.github.datallmhub.agentflow4j:agentflow4j-starter:v0.6.0' }
+dependencies { implementation 'com.github.datallmhub.agentflow4j:agentflow4j-starter:v0.7.0' }
 ```
 
 ### Modules

--- a/agentflow4j-checkpoint/pom.xml
+++ b/agentflow4j-checkpoint/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.datallmhub</groupId>
         <artifactId>agentflow4j-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>agentflow4j-checkpoint</artifactId>

--- a/agentflow4j-cli-agents/pom.xml
+++ b/agentflow4j-cli-agents/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.datallmhub</groupId>
         <artifactId>agentflow4j-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>agentflow4j-cli-agents</artifactId>

--- a/agentflow4j-core/pom.xml
+++ b/agentflow4j-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.datallmhub</groupId>
         <artifactId>agentflow4j-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>agentflow4j-core</artifactId>

--- a/agentflow4j-graph/pom.xml
+++ b/agentflow4j-graph/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.datallmhub</groupId>
         <artifactId>agentflow4j-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>agentflow4j-graph</artifactId>

--- a/agentflow4j-playground/pom.xml
+++ b/agentflow4j-playground/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.datallmhub</groupId>
         <artifactId>agentflow4j-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>agentflow4j-playground</artifactId>

--- a/agentflow4j-resilience4j/pom.xml
+++ b/agentflow4j-resilience4j/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.datallmhub</groupId>
         <artifactId>agentflow4j-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>agentflow4j-resilience4j</artifactId>

--- a/agentflow4j-samples/pom.xml
+++ b/agentflow4j-samples/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.datallmhub</groupId>
         <artifactId>agentflow4j-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>agentflow4j-samples</artifactId>

--- a/agentflow4j-squad/pom.xml
+++ b/agentflow4j-squad/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.datallmhub</groupId>
         <artifactId>agentflow4j-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>agentflow4j-squad</artifactId>

--- a/agentflow4j-starter/pom.xml
+++ b/agentflow4j-starter/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.datallmhub</groupId>
         <artifactId>agentflow4j-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>agentflow4j-starter</artifactId>

--- a/agentflow4j-test/pom.xml
+++ b/agentflow4j-test/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.github.datallmhub</groupId>
         <artifactId>agentflow4j-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>agentflow4j-test</artifactId>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ AgentFlow4J is distributed via [JitPack](https://jitpack.io/#datallmhub/agentflo
     <dependency>
         <groupId>com.github.datallmhub.agentflow4j</groupId>
         <artifactId>agentflow4j-starter</artifactId>
-        <version>v0.6.0</version>
+        <version>v0.7.0</version>
     </dependency>
     ```
 
@@ -41,7 +41,7 @@ AgentFlow4J is distributed via [JitPack](https://jitpack.io/#datallmhub/agentflo
     repositories { maven { url 'https://jitpack.io' } }
 
     dependencies {
-        implementation 'com.github.datallmhub.agentflow4j:agentflow4j-starter:v0.6.0'
+        implementation 'com.github.datallmhub.agentflow4j:agentflow4j-starter:v0.7.0'
     }
     ```
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -45,5 +45,5 @@ License: Apache 2.0. Package: `com.github.datallmhub.agentflow4j:agentflow4j-sta
 ## Source & install
 
 - Repository: [github.com/datallmhub/agentflow4j](https://github.com/datallmhub/agentflow4j)
-- Maven (JitPack): `com.github.datallmhub.agentflow4j:agentflow4j-starter:v0.6.0`
+- Maven (JitPack): `com.github.datallmhub.agentflow4j:agentflow4j-starter:v0.7.0`
 - Modules: `agentflow4j-core`, `agentflow4j-graph`, `agentflow4j-squad`, `agentflow4j-checkpoint`, `agentflow4j-resilience4j`, `agentflow4j-starter`, `agentflow4j-playground`, `agentflow4j-cli-agents`, `agentflow4j-test`, `agentflow4j-samples`

--- a/docs/tutorials/free-mistral-quickstart.md
+++ b/docs/tutorials/free-mistral-quickstart.md
@@ -49,7 +49,7 @@ In a Spring Boot project, add the AgentFlow4J starter (via [JitPack](https://jit
     <dependency>
         <groupId>com.github.datallmhub.agentflow4j</groupId>
         <artifactId>agentflow4j-starter</artifactId>
-        <version>v0.6.0</version>
+        <version>v0.7.0</version>
     </dependency>
 
     <!-- Spring AI — Mistral -->
@@ -65,7 +65,7 @@ In a Spring Boot project, add the AgentFlow4J starter (via [JitPack](https://jit
     repositories { maven { url 'https://jitpack.io' } }
 
     dependencies {
-        implementation 'com.github.datallmhub.agentflow4j:agentflow4j-starter:v0.6.0'
+        implementation 'com.github.datallmhub.agentflow4j:agentflow4j-starter:v0.7.0'
         implementation 'org.springframework.ai:spring-ai-starter-model-mistral-ai'
     }
     ```

--- a/docs/tutorials/stop-your-agent-burning-money.md
+++ b/docs/tutorials/stop-your-agent-burning-money.md
@@ -23,7 +23,7 @@ We'll build a customer-support agent that can issue refunds, then lock it down s
 <dependency>
     <groupId>com.github.datallmhub.agentflow4j</groupId>
     <artifactId>agentflow4j-starter</artifactId>
-    <version>v0.6.0</version>
+    <version>v0.7.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.datallmhub</groupId>
     <artifactId>agentflow4j-parent</artifactId>
-    <version>0.6.0</version>
+    <version>0.7.0</version>
     <packaging>pom</packaging>
 
     <name>AgentFlow4J</name>


### PR DESCRIPTION
Ships the two features merged after v0.6.0:
- reason-aware RetryPolicy (TRANSIENT / PERMANENT / OVER_BUDGET, #14)
- budget-aware RoutingStrategy fallback (#15)

Bumps all module poms 0.6.0 -> 0.7.0 and the JitPack starter coordinate (v0.7.0) across README, getting-started, llms.txt and the tutorials so the docs match a consumable artifact.